### PR TITLE
use on/to in build-packages, fix --target-arch use

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ projects better than what is available with Github issues.
 
 To build the gadget snap locally on an armhf system please use `snapcraft`.
 
-To cross build this gadget snap on a PC please install the gcc-arm-linux-gnueabihf package
-before running `snapcraft --target-arch=armhf`
+To cross build this gadget snap on a PC please run `snapcraft --target-arch=armhf`
 
 ## Launchpad Mirror and Automatic Builds.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ projects better than what is available with Github issues.
 To build the gadget snap locally on an armhf system please use `snapcraft`.
 
 To cross build this gadget snap on a PC please install the gcc-arm-linux-gnueabihf package
-before running `snapcraft`
+before running `snapcraft --target-arch=armhf`
 
 ## Launchpad Mirror and Automatic Builds.
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: cm3
-version: 16.04-0.5
+version: 16.04-0.6
 summary: Raspberry Compute Module 3 support package
 description: |
  Support files for booting Raspberry Compute Module 3
@@ -10,7 +10,7 @@ confinement: strict
 grade: stable
 parts:
   uboot:
-    plugin: make
+    plugin: nil
     source: git://git.denx.de/u-boot.git
     source-branch: v2017.05
     prepare: |
@@ -18,10 +18,6 @@ parts:
       make rpi_3_32b_defconfig
     build: |
       if [ "$(arch)" = "x86_64" ]; then
-        if [ ! -x /usr/bin/arm-linux-gnueabihf-gcc ]; then
-          echo "ERROR: You are cross building this snap, please install gcc-arm-linux-gnueabihf"
-          exit 1
-        fi
         CROSS_COMPILE=arm-linux-gnueabihf- make
       else
         make
@@ -37,6 +33,8 @@ parts:
       - device-tree-compiler
       - libpython2.7-dev
       - python-minimal
+      - on amd64 to armhf:
+          - gcc-arm-linux-gnueabihf:amd64
   boot-firmware:
     plugin: nil
     source: .


### PR DESCRIPTION
Drop the old cross compiler error message and use on/to in build-packages instead
Switch to "nil" plugin so snapcraft --target-arch=armhf works

(details at https://forum.snapcraft.io/t/customised-cm3-image-fails-on-reboot/5336 )