### PR TITLE
snapcraft.yaml: updated for UC18

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: cm3
-version: 16.04-0.6
+version: 18-1
 summary: Raspberry Compute Module 3 support package
 description: |
  Support files for booting Raspberry Compute Module 3
@@ -41,7 +41,7 @@ parts:
     after:
       - uboot
     prepare: |
-      git clone --depth=1 https://github.com/raspberrypi/firmware.git -b "1.20170515"
+      git clone --depth=1 https://github.com/raspberrypi/firmware.git -b "1.20180619"
     install: |
       mkdir -p $SNAPCRAFT_PART_INSTALL/boot-assets
       for file in fixup start bootcode LICENCE COPYING; do
@@ -61,9 +61,9 @@ parts:
     after:
       - configs
     prepare: |
-      PACKAGES="http://ports.ubuntu.com/ubuntu-ports/dists/xenial-updates/universe/binary-armhf/Packages.gz"
+      PACKAGES="http://ports.ubuntu.com/ubuntu-ports/dists/bionic-updates/universe/binary-armhf/Packages.gz"
       PKGPATH="$(wget -q -O- $PACKAGES|zcat|grep-dctrl linux-raspi2 |\
-        grep linux-image|grep Filename|tail -1| sed 's/^Filename: //')"
+        grep linux-modules|grep Filename|tail -1| sed 's/^Filename: //')"
       wget http://ports.ubuntu.com/ubuntu-ports/$PKGPATH
       dpkg -x $(basename $PKGPATH) unpack/
     install: |


### PR DESCRIPTION
This updates the pi3-gadget to work with UC18 and the 4.15 kernel. This is aimed to the "18" track of the pi3 gadget.